### PR TITLE
Nested schema.

### DIFF
--- a/daprot/mapper.py
+++ b/daprot/mapper.py
@@ -30,3 +30,7 @@ def INDEX(field):
 # NoneType
 def IGNORE(field):
     return None
+
+# str
+def INHERITED(field):
+    return ''

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 import sys, os
 
-version = '1.0.1'
+version = '1.1.0'
 
 setup(
     name = 'daprot',


### PR DESCRIPTION
Many people asked me to add nested schema support for [mETL](https://github.com/ceumicrodata/mETL) library. `daprot` will be the new data prototyping package for mETL v2.0.

This is the goal:

``` python
class Contact(dp.SchemaFlow):
    phone_number = dp.Field('contact/phone')
    twitter_id = dp.Field('contact/twitter')
    facebook_id = dp.Field('contact/facebook')
    address = dp.Field('location/address')
    postal_code = dp.Field('location/postalCode', type=t.Int)
    city = dp.Field('location/city')
    country = dp.Field('location/country')
    latitude = dp.Field('location/lat', type=float)
    longitude = dp.Field('location/lng', type=float)

class Category(dp.SchemaFlow):
    category_id = dp.Field('id')
    name = dp.Field()

class Venues(dp.SchemaFlow):
    venue_id = dp.Field('id')
    name = dp.Field()
    categories = dp.ListOf(Category, route='categories')
    contact = dp.DictOf(Contact)
    check_in_count = dp.Field('stats/checkinsCount', type=int)
    tip_count = dp.Field('stats/tipCount', type=int)
```
